### PR TITLE
feat(action/run): support single file in sourceDir

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,12 @@ const S3 = new S3Client({
 
 const getFileList = (dir: string) => {
     let files: string[] = [];
+
+    if (fs.statSync(dir).isFile()) {
+        files.push(fs.realpathSync(dir));
+        return files;
+    }
+
     const items = fs.readdirSync(dir, {
         withFileTypes: true,
     });
@@ -62,7 +68,7 @@ const run = async (config: R2Config) => {
         console.log(config.sourceDir);
         console.log(config.destinationDir);
         //const fileName = file.replace(/^.*[\\\/]/, "");
-        const fileName = file.replace(config.sourceDir, "");
+        const fileName = path.basename(file);
         const fileKey = path.join(config.destinationDir !== "" ? config.destinationDir : config.sourceDir, fileName);
 
         if (fileKey.includes('.gitkeep'))


### PR DESCRIPTION
I added checks before parsing the file lists as directory and return the file if dir is a file. 

Also fix the fileName retrieval. Please check. 

Now, the `source-dir` could refer to a single file. 

Closes #406 

