### PR TITLE
fix: unable to override default parameters

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ let config: R2Config = {
     multiPartSize: parseInt(getInput("multipart-size")) || 100,
     maxTries: parseInt(getInput("max-retries")) || 5,
     multiPartConcurrent: getInput("multipart-concurrent") === 'true',
-    keepFileFresh: getInput("keep-file-fresh") === 'false'
+    keepFileFresh: getInput("keep-file-fresh") === 'true' || false
 };
 
 const S3 = new S3Client({


### PR DESCRIPTION
I found that the default variables couldn't be overridden：
```
Run ./r2-upload-action
  with:
    r2-account-id: ***
    r2-access-key-id: ***
    r2-secret-access-key: ***
    r2-bucket: ***
    source-dir: /home/runner/work/myAUR/myAUR
    destination-dir: archlinux/test
    keep-***-fresh: true
    output-***-url: true
    multipart-size: 100
    max-retries: 5
    multipart-concurrent: true
/usr/bin/docker exec  b8410f562f004919b3c2ff11fa1ed38eb158f479ec5521b2165a0015abbaf038 sh -c "cat /etc/*release | grep ^ID"
debug: Config.keepFileFresh: false
```
Secondly, I found that other variables with default values seem to have the same problem, such as `multipart-concurrent`and `output-file-url`. I tried to fix them the same way but it doesn't seem to work, you may need to reconfirm it.