### PR TITLE
Fix path problem on Windows

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -93,7 +93,10 @@ const run = async (config: R2Config) => {
         console.log(config.destinationDir);
         //const fileName = file.replace(config.sourceDir, "");
         const fileName = files[file];
-        const fileKey = path.join(config.destinationDir !== "" ? config.destinationDir : config.sourceDir, fileName);
+        // const fileKey = path.join(config.destinationDir !== "" ? config.destinationDir : config.sourceDir, fileName);
+
+        const destinationDir = config.destinationDir.split(path.sep).join('/');
+        const fileKey = path.posix.join(destinationDir !== "" ? destinationDir : config.sourceDir.split(path.sep).join('/'), fileName.split(path.sep).join('/'));
 
         if (fileName.includes('.gitkeep'))
             continue;


### PR DESCRIPTION
I tested it on Ubuntu 22.04, MacOS 14, and Windows 10. It resolves the path issue on Windows.