### PR TITLE
ci(test-nix): replace magic nix cache with flakehub cache

### DIFF
--- a/.github/workflows/test-nix.yml
+++ b/.github/workflows/test-nix.yml
@@ -10,12 +10,18 @@ jobs:
     name: Build Nix Shell
     runs-on: ubuntu-latest
 
+    permissions:
+      id-token: write
+      contents: read
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v16
-      - name: Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@v9
+        with:
+          determinate: true
+      - name: FlakeHub Cache
+        uses: DeterminateSystems/flakehub-cache-action@v1
       - name: Build
         run: nix-build shell.nix


### PR DESCRIPTION
Magic Nix Cache is deprecated, switch to Flakehub Cache.